### PR TITLE
Enhanced surface salinity restoring

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -922,12 +922,24 @@ if ($OCN_FORCING eq 'datm_forced_restoring') {
 	add_default($nl, 'config_salinity_restoring_constant_piston_velocity', 'val'=>"1.585e-6");
 	add_default($nl, 'config_salinity_restoring_max_difference', 'val'=>"100.");
 	add_default($nl, 'config_salinity_restoring_under_sea_ice', 'val'=>".false.");
+	add_default($nl, 'config_enhanced_salinity_restoring', 'val'=>".false.");
+	add_default($nl, 'config_enhanced_salinity_restoring_factor', 'val'=>"1.0");
+	add_default($nl, 'config_enhanced_salinity_restoring_lat_south', 'val'=>"0.0");
+	add_default($nl, 'config_enhanced_salinity_restoring_lat_north', 'val'=>"0.0");
+        add_default($nl, 'config_enhanced_salinity_restoring_lon_west', 'val'=>"0.0");
+	add_default($nl, 'config_enhanced_salinity_restoring_lon_east', 'val'=>"0.0");
 } else {
 	add_default($nl, 'config_use_activeTracers_surface_restoring');
 	add_default($nl, 'config_use_surface_salinity_monthly_restoring');
 	add_default($nl, 'config_salinity_restoring_constant_piston_velocity');
 	add_default($nl, 'config_salinity_restoring_max_difference');
 	add_default($nl, 'config_salinity_restoring_under_sea_ice');
+	add_default($nl, 'config_enhanced_salinity_restoring');
+        add_default($nl, 'config_enhanced_salinity_restoring_factor');
+        add_default($nl, 'config_enhanced_salinity_restoring_lat_south');
+	add_default($nl, 'config_enhanced_salinity_restoring_lat_north');
+        add_default($nl, 'config_enhanced_salinity_restoring_lon_west');
+        add_default($nl, 'config_enhanced_salinity_restoring_lon_east');
 }
 add_default($nl, 'config_surface_salinity_monthly_restoring_compute_interval');
 add_default($nl, 'config_use_activeTracers_interior_restoring');

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -459,6 +459,12 @@ add_default($nl, 'config_surface_salinity_monthly_restoring_compute_interval');
 add_default($nl, 'config_salinity_restoring_constant_piston_velocity');
 add_default($nl, 'config_salinity_restoring_max_difference');
 add_default($nl, 'config_salinity_restoring_under_sea_ice');
+add_default($nl, 'config_enhanced_salinity_restoring');
+add_default($nl, 'config_enhanced_salinity_restoring_factor');
+add_default($nl, 'config_enhanced_salinity_restoring_lat_south');
+add_default($nl, 'config_enhanced_salinity_restoring_lat_north');
+add_default($nl, 'config_enhanced_salinity_restoring_lon_west');
+add_default($nl, 'config_enhanced_salinity_restoring_lon_east');
 
 ###############################################
 # Namelist group: tracer_forcing_debugTracers #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -479,6 +479,12 @@
 <config_salinity_restoring_constant_piston_velocity>1.585e-6</config_salinity_restoring_constant_piston_velocity>
 <config_salinity_restoring_max_difference>0.5</config_salinity_restoring_max_difference>
 <config_salinity_restoring_under_sea_ice>.false.</config_salinity_restoring_under_sea_ice>
+<config_enhanced_salinity_restoring>.false.</config_enhanced_salinity_restoring>
+<config_enhanced_salinity_restoring_factor>1.0</config_enhanced_salinity_restoring_factor>
+<config_enhanced_salinity_restoring_lat_south>0.0</config_enhanced_salinity_restoring_lat_south>
+<config_enhanced_salinity_restoring_lat_north>0.0</config_enhanced_salinity_restoring_lat_north>
+<config_enhanced_salinity_restoring_lon_west>0.0</config_enhanced_salinity_restoring_lon_west>
+<config_enhanced_salinity_restoring_lon_east>0.0</config_enhanced_salinity_restoring_lon_east>
 
 <!-- tracer_forcing_debugTracers -->
 <config_use_debugTracers>.false.</config_use_debugTracers>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -2328,6 +2328,53 @@ Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_enhanced_salinity_restoring" type="logical"
+       category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+When config_enhanced_salinity_restoring is true, enhanced salinity forcing is set within the bounds set by config_enhanced_salinity_restoring_lat_south, config_enhanced_salinity_restoring_lat_north, config_enhanced_salinity_restoring_lon_west, and config_enhanced_salinity_restoring_lon_east at a factor according to config_enhanced_salinity_restoring_factor
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_enhanced_salinity_restoring_factor" type="real"
+       category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+Factor that salinity restoring is enhanced by, if config_enhanced_salinity_restoring is true
+
+Valid values: any non-negative number
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_enhanced_salinity_restoring_lat_south" type="real"
+       category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+Southern boundary of salinity restoring enhancement, if config_enhanced_salinity_restoring is true
+
+Valid values: between -pi/2 and pi/2
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_enhanced_salinity_restoring_lat_north" type="real"
+       category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+Northern boundary of salinity restoring enhancement, if config_enhanced_salinity_restoring is true
+
+Valid values: between -pi/2 and pi/2
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_enhanced_salinity_restoring_lon_west" type="real"
+       category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+Western boundary of salinity restoring enhancement, if config_enhanced_salinity_restoring is true
+
+Valid values: between zero and 2*pi
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_enhanced_salinity_restoring_lon_east" type="real"
+       category="tracer_forcing_activeTracers" group="tracer_forcing_activeTracers">
+Eastern boundary of salinity restoring enhancement, if config_enhanced_salinity_restoring is true
+
+Valid values: between zero and 2*pi
+Default: Defined in namelist_defaults.xml
+</entry>
 
 <!-- tracer_forcing_debugTracers -->
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -124,12 +124,7 @@ contains
          call ocn_surface_bulk_forcing_active_tracers(meshPool, forcingPool, tracerGroup,  &
             tracersSurfaceFlux, tracersSurfaceFluxRunoff, tracersSurfaceFluxRemoved, layerThickness, dt, err)
       end if
-      if ( trim(groupName) == 'debugTracers' ) then 
-         call ocn_surface_bulk_forcing_debug_tracers(meshPool, forcingPool, tracerGroup, &
-            tracersSurfaceFlux, err)
-      end if
       call mpas_timer_stop("bulk_" // trim(groupName))
-
 
    end subroutine ocn_surface_bulk_forcing_tracers!}}}
 
@@ -597,82 +592,8 @@ contains
 
    end subroutine ocn_surface_bulk_forcing_active_tracers!}}}
 
-!***********************************************************************
-!
-!  routine ocn_surface_bulk_forcing_debug_tracers
-!
-!> \brief   Determines the debug tracers forcing array used for the bulk forcing.
-!> \author  Kat Smith
-!> \date    01/25/2022
-!> \details
-!>  This routine computes the debug tracers forcing arrays used later in MPAS.
-!
-!-----------------------------------------------------------------------
-
-   subroutine ocn_surface_bulk_forcing_debug_tracers(meshPool, forcingPool, tracerGroup,  &
-      tracersSurfaceFlux, err)
-
-      !-----------------------------------------------------------------
-      !
-      ! input variables
-      !
-      !-----------------------------------------------------------------
-      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
-
-      !-----------------------------------------------------------------
-      !
-      ! input/output variables
-      !
-      !-----------------------------------------------------------------
-      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
-      real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFlux
-      real (kind=RKIND), dimension(:,:,:), intent(inout) :: tracerGroup
-
-      !-----------------------------------------------------------------
-      !
-      ! output variables
-      !
-      !-----------------------------------------------------------------
-
-      integer, intent(out) :: err !< Output: Error flag
-
-      !-----------------------------------------------------------------
-      !
-      ! local variables
-      !
-      !-----------------------------------------------------------------
-
-      integer :: iCell, nCells
-      integer, pointer :: index_debug_flux
-      integer, dimension(:), pointer :: nCellsArray
-
-      type(mpas_pool_type),pointer :: tracersSurfaceFluxPool
-
-      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux
-
-      err = 0
-
-      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
-      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux',tracersSurfaceFluxPool)
-      
-      call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_tracer1SurfaceFlux', index_debug_flux)
-      
-      call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
-
-      nCells = nCellsArray( 3 )
-
-      ! Build surface fluxes at cell centers
-      !$omp parallel
-      !$omp do schedule(runtime) 
-      do iCell = 1, nCells
-        tracersSurfaceFlux(index_debug_flux, iCell) = seaIceFreshWaterFlux(iCell)
-      end do
-      !$omp end do
-      !$omp end parallel
-
-   end subroutine ocn_surface_bulk_forcing_debug_tracers!}}}
-
 end module ocn_surface_bulk_forcing
+
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -124,7 +124,12 @@ contains
          call ocn_surface_bulk_forcing_active_tracers(meshPool, forcingPool, tracerGroup,  &
             tracersSurfaceFlux, tracersSurfaceFluxRunoff, tracersSurfaceFluxRemoved, layerThickness, dt, err)
       end if
+      if ( trim(groupName) == 'debugTracers' ) then 
+         call ocn_surface_bulk_forcing_debug_tracers(meshPool, forcingPool, tracerGroup, &
+            tracersSurfaceFlux, err)
+      end if
       call mpas_timer_stop("bulk_" // trim(groupName))
+
 
    end subroutine ocn_surface_bulk_forcing_tracers!}}}
 
@@ -592,8 +597,82 @@ contains
 
    end subroutine ocn_surface_bulk_forcing_active_tracers!}}}
 
-end module ocn_surface_bulk_forcing
+!***********************************************************************
+!
+!  routine ocn_surface_bulk_forcing_debug_tracers
+!
+!> \brief   Determines the debug tracers forcing array used for the bulk forcing.
+!> \author  Kat Smith
+!> \date    01/25/2022
+!> \details
+!>  This routine computes the debug tracers forcing arrays used later in MPAS.
+!
+!-----------------------------------------------------------------------
 
+   subroutine ocn_surface_bulk_forcing_debug_tracers(meshPool, forcingPool, tracerGroup,  &
+      tracersSurfaceFlux, err)
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFlux
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: tracerGroup
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, nCells
+      integer, pointer :: index_debug_flux
+      integer, dimension(:), pointer :: nCellsArray
+
+      type(mpas_pool_type),pointer :: tracersSurfaceFluxPool
+
+      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux
+
+      err = 0
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux',tracersSurfaceFluxPool)
+      
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_tracer1SurfaceFlux', index_debug_flux)
+      
+      call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
+
+      nCells = nCellsArray( 3 )
+
+      ! Build surface fluxes at cell centers
+      !$omp parallel
+      !$omp do schedule(runtime) 
+      do iCell = 1, nCells
+        tracersSurfaceFlux(index_debug_flux, iCell) = seaIceFreshWaterFlux(iCell)
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_surface_bulk_forcing_debug_tracers!}}}
+
+end module ocn_surface_bulk_forcing
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_surface_restoring.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_surface_restoring.F
@@ -229,7 +229,8 @@ contains
         type (mpas_pool_type), pointer :: tracersSurfaceRestoringFieldsPool
 
         real (kind=RKIND), dimension(:), pointer :: &
-           surfaceSalinityMonthlyClimatologyValue, iceFraction, areaCell
+           surfaceSalinityMonthlyClimatologyValue, iceFraction, areaCell, &
+           latCell, lonCell
 
         real (kind=RKIND), dimension(:,:), pointer :: &
            activeTracersSurfaceRestoringValue

--- a/components/mpas-ocean/src/shared/mpas_ocn_tracer_surface_restoring.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_tracer_surface_restoring.F
@@ -249,6 +249,8 @@ contains
         integer, parameter :: nSums = 2
         real (kind=RKIND), dimension(nSums) :: reductions, sums
 
+        real (kind=RKIND) :: lat_north, lat_south, lon_east, lon_west
+
         ! initialize monthly forcing to be read from file
 
         if (firstTimeStep) then
@@ -442,6 +444,14 @@ contains
         call mpas_pool_get_dimension(tracersSurfaceRestoringFieldsPool, 'index_salinitySurfaceRestoringValue',  &
                                                                          indexSalinitySurfaceRestoringValue)
 
+        call mpas_pool_get_array(meshPool, 'latCell', latCell)
+        call mpas_pool_get_array(meshPool, 'lonCell', lonCell)
+        
+        lat_south = config_enhanced_salinity_restoring_lat_south
+        lat_north = config_enhanced_salinity_restoring_lat_north
+        lon_west = config_enhanced_salinity_restoring_lon_west
+        lon_east = config_enhanced_salinity_restoring_lon_east
+
         do iCell = 1, nCells
           deltaS = activeTracersSurfaceRestoringValue(indexSalinitySurfaceRestoringValue,iCell)
           if (deltaS .ne. 0.0_RKIND) then
@@ -450,6 +460,20 @@ contains
              salinitySurfaceRestoringTendency(iCell) = &
                 activeTracersSurfaceRestoringValue(indexSalinitySurfaceRestoringValue,iCell) &
                 * config_salinity_restoring_constant_piston_velocity
+             if (config_enhanced_salinity_restoring .and. (latCell(iCell) .ge. lat_south) &
+                .and. (latCell(iCell) .le. lat_north)) then
+                if (lon_west .gt. lon_east) then
+                   if ((lonCell(iCell) .ge. lon_west) .or. (lonCell(iCell) .le. lon_east)) then
+                      salinitySurfaceRestoringTendency(iCell) = &
+                         salinitySurfaceRestoringTendency(iCell) * config_enhanced_salinity_restoring_factor
+                   endif
+                else
+                   if ((lonCell(iCell) .ge. lon_west) .and. (lonCell(iCell) .le. lon_east)) then
+                      salinitySurfaceRestoringTendency(iCell) = &
+                         salinitySurfaceRestoringTendency(iCell) * config_enhanced_salinity_restoring_factor
+                   endif
+                endif
+             endif
           else
              salinitySurfaceRestoringTendency(iCell) = 0.0_RKIND
           endif

--- a/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_activeTracers.xml
@@ -47,6 +47,33 @@
 			description="Flag to enable salinity restoring under sea ice.  The default setting is false, where salinity restoring tapers from full restoring in the open ocean (iceFraction=0.0) to zero restoring below full sea ice coverage (iceFraction=1.0); below partial sea ice coverage, restoring is in proportion to iceFraction.  If true, full salinity restoring is used everywhere, regardless of iceFraction value"
 			possible_values=".true. or .false."
 		/>
+		<nml_option name="config_enhanced_salinity_restoring" type="logical" default_value=".false." units="NA"
+			description="When config_enhanced_salinity_restoring is true, enhanced salinity forcing is set within th\
+e bounds set by config_enhanced_salinity_restoring_lat_south, config_enhanced_salinity_restoring_lat_north, config_enhanced_sali\
+nity_restoring_lon_west, and config_enhanced_salinity_restoring_lon_east at a factor according to config_enhanced_salinity_resto\
+ring_factor"
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_enhanced_salinity_restoring_factor" type="real" default_value="1.0" units="NA"
+			description="Factor that salinity restoring is enhanced by, if config_enhanced_salinity_restoring is true"
+			possible_values="any non-negative number"
+		/>
+                <nml_option name="config_enhanced_salinity_restoring_lat_south" type="real" default_value="0.0" units="radians"
+			description="Southern boundary of salinity restoring enhancement, if config_enhanced_salinity_restoring is true"
+			possible_values="between -pi/2 and pi/2"
+		/>
+                <nml_option name="config_enhanced_salinity_restoring_lat_north" type="real" default_value="0.0" units="radians"
+			description="Northern boundary of salinity restoring enhancement, if config_enhanced_salinity_restoring is true"
+			possible_values="between -pi/2 and pi/2"
+		/>
+                <nml_option name="config_enhanced_salinity_restoring_lon_west" type="real" default_value="0.0" units="radians"
+			description="Western boundary of salinity restoring enhancement, if config_enhanced_salinity_restoring is true"
+			possible_values="between zero and 2*pi"
+		/>
+                <nml_option name="config_enhanced_salinity_restoring_lon_east" type="real" default_value="0.0" units="radians"
+			description="Eastern boundary of salinity restoring enhancement, if config_enhanced_salinity_restoring is true"
+			possible_values="between zero and 2*pi"
+		/>
 	</nml_record>
 
 	<packages>


### PR DESCRIPTION
This PR adds the ability to enhance surface salinity restoring by a factor, either across the entire globe or just within a lat/lon defined box.

Set `config_enhanced_salinity_restoring = .true.` to turn on. 
Set `config_enhanced_salinity_restoring_factor` to whatever enhancement factor desired.
Set `config_enhanced_salinity_restoring_lat_south`/`_lat_north`/`_lon_west`/`_lon_east` to desired boundaries of enhancement box (in radians). 