### PR TITLE
Debug tracer equal to seaIceFreshWaterFlux

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -659,13 +659,11 @@ contains
       
       call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
 
-      nCells = nCellsArray( 3 )
-
-      ! Build surface fluxes at cell centers
+      ! Build debug tracer flux at cell centers
       !$omp parallel
       !$omp do schedule(runtime) 
-      do iCell = 1, nCells
-        tracersSurfaceFlux(index_debug_flux, iCell) = seaIceFreshWaterFlux(iCell)
+      do iCell = 1, nCellsAll
+        tracersSurfaceFlux(index_debug_flux, iCell) = seaIceFreshWaterFlux(iCell) / rho_sw
       end do
       !$omp end do
       !$omp end parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -124,7 +124,12 @@ contains
          call ocn_surface_bulk_forcing_active_tracers(meshPool, forcingPool, tracerGroup,  &
             tracersSurfaceFlux, tracersSurfaceFluxRunoff, tracersSurfaceFluxRemoved, layerThickness, dt, err)
       end if
+      if ( trim(groupName) == 'debugTracers' ) then 
+         call ocn_surface_bulk_forcing_debug_tracers(meshPool, forcingPool, tracerGroup, &
+            tracersSurfaceFlux, err)
+      end if
       call mpas_timer_stop("bulk_" // trim(groupName))
+
 
    end subroutine ocn_surface_bulk_forcing_tracers!}}}
 
@@ -592,8 +597,82 @@ contains
 
    end subroutine ocn_surface_bulk_forcing_active_tracers!}}}
 
-end module ocn_surface_bulk_forcing
+!***********************************************************************
+!
+!  routine ocn_surface_bulk_forcing_debug_tracers
+!
+!> \brief   Determines the debug tracers forcing array used for the bulk forcing.
+!> \author  Kat Smith
+!> \date    01/25/2022
+!> \details
+!>  This routine computes the debug tracers forcing arrays used later in MPAS.
+!
+!-----------------------------------------------------------------------
 
+   subroutine ocn_surface_bulk_forcing_debug_tracers(meshPool, forcingPool, tracerGroup,  &
+      tracersSurfaceFlux, err)
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(in) :: meshPool !< Input: mesh information
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: forcingPool !< Input: Forcing information
+      real (kind=RKIND), dimension(:,:), intent(inout) :: tracersSurfaceFlux
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: tracerGroup
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: Error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iCell, nCells
+      integer, pointer :: index_debug_flux
+      integer, dimension(:), pointer :: nCellsArray
+
+      type(mpas_pool_type),pointer :: tracersSurfaceFluxPool
+
+      real (kind=RKIND), dimension(:), pointer :: seaIceFreshWaterFlux
+
+      err = 0
+
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
+      call mpas_pool_get_subpool(forcingPool, 'tracersSurfaceFlux',tracersSurfaceFluxPool)
+      
+      call mpas_pool_get_dimension(tracersSurfaceFluxPool, 'index_tracer1SurfaceFlux', index_debug_flux)
+      
+      call mpas_pool_get_array(forcingPool, 'seaIceFreshWaterFlux', seaIceFreshWaterFlux)
+
+      nCells = nCellsArray( 3 )
+
+      ! Build surface fluxes at cell centers
+      !$omp parallel
+      !$omp do schedule(runtime) 
+      do iCell = 1, nCells
+        tracersSurfaceFlux(index_debug_flux, iCell) = seaIceFreshWaterFlux(iCell)
+      end do
+      !$omp end do
+      !$omp end parallel
+
+   end subroutine ocn_surface_bulk_forcing_debug_tracers!}}}
+
+end module ocn_surface_bulk_forcing
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 ! vim: foldmethod=marker

--- a/components/mpas-ocean/src/tracer_groups/Registry_debugTracers.xml
+++ b/components/mpas-ocean/src/tracer_groups/Registry_debugTracers.xml
@@ -49,7 +49,7 @@
 
 	<var_struct name="state" time_levs="2">
 		<var_struct name="tracers" time_levs="2">
-			<var_array name="debugTracers" dimensions="nVertLevels nCells Time" type="real" packages="debugTracersPKG" default_value="1.0">
+			<var_array name="debugTracers" dimensions="nVertLevels nCells Time" type="real" packages="debugTracersPKG" default_value="0.0">
 				<var name="tracer1" array_group="debugGRP" units="tracer1"
 			 description="tracer for debugging purposes"
 				/>


### PR DESCRIPTION
This PR adds a debug tracer to the bulk forcing file that has a source/sink equal to `seaIceFreshWaterFlux`

To enable, set `config_use_debugTracers = .true.` and `config_use_debugTracers_surface_bulk_forcing = .true.`